### PR TITLE
test: add tensor arithmetic tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,3 +88,6 @@ target_include_directories(${PROJECT_NAME} PUBLIC ${CUDAToolkit_INCLUDE_DIRS})
 foreach(path IN LISTS CUDA_LIB_PATH_LIST)
         target_link_directories(${PROJECT_NAME}  PUBLIC ${path} )
 endforeach()
+
+enable_testing()
+add_subdirectory(tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,13 @@
+include(FetchContent)
+
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/refs/tags/release-1.12.1.zip
+)
+
+FetchContent_MakeAvailable(googletest)
+
+add_executable(tensor_ops_test tensor_ops_test.cpp)
+target_link_libraries(tensor_ops_test PRIVATE OpenMat cuda cudart GTest::gtest_main)
+
+add_test(NAME tensor_ops_test COMMAND tensor_ops_test)

--- a/tests/tensor_ops_test.cpp
+++ b/tests/tensor_ops_test.cpp
@@ -1,0 +1,66 @@
+#include <gtest/gtest.h>
+#include "tensor.cuh"
+#include "mat_utils.h"
+#include <vector>
+
+using namespace om;
+
+TEST(TensorArithmetic, CPUOperations) {
+    Device cpu("cpu:0");
+    Tensor<float> a({2}, cpu);
+    Tensor<float> b({2}, cpu);
+
+    a({0}) = 1.0f;
+    a({1}) = 2.0f;
+    b({0}) = 3.0f;
+    b({1}) = 4.0f;
+
+    Tensor<float> add_res = a + b;
+    EXPECT_FLOAT_EQ(add_res({0}), 4.0f);
+    EXPECT_FLOAT_EQ(add_res({1}), 6.0f);
+
+    Tensor<float> sub_res = a - b;
+    EXPECT_FLOAT_EQ(sub_res({0}), -2.0f);
+    EXPECT_FLOAT_EQ(sub_res({1}), -2.0f);
+
+    Tensor<float> mul_res = a * b;
+    EXPECT_FLOAT_EQ(mul_res({0}), 3.0f);
+    EXPECT_FLOAT_EQ(mul_res({1}), 8.0f);
+
+    Tensor<float> div_res = a / b;
+    EXPECT_FLOAT_EQ(div_res({0}), 1.0f/3.0f);
+    EXPECT_FLOAT_EQ(div_res({1}), 0.5f);
+}
+
+TEST(TensorArithmetic, GPUOperations) {
+    Device gpu("cuda:0");
+    Tensor<float> a({2}, gpu);
+    Tensor<float> b({2}, gpu);
+
+    a.fill(1.0f);
+    b.fill(2.0f);
+
+    Tensor<float> add_res = a + b;
+    Tensor<float> sub_res = a - b;
+    Tensor<float> mul_res = a * b;
+    Tensor<float> div_res = a / b;
+
+    std::vector<float> host(2);
+
+    add_res.copyToHost(host.data());
+    EXPECT_FLOAT_EQ(host[0], 3.0f);
+    EXPECT_FLOAT_EQ(host[1], 3.0f);
+
+    sub_res.copyToHost(host.data());
+    EXPECT_FLOAT_EQ(host[0], -1.0f);
+    EXPECT_FLOAT_EQ(host[1], -1.0f);
+
+    mul_res.copyToHost(host.data());
+    EXPECT_FLOAT_EQ(host[0], 2.0f);
+    EXPECT_FLOAT_EQ(host[1], 2.0f);
+
+    div_res.copyToHost(host.data());
+    EXPECT_FLOAT_EQ(host[0], 0.5f);
+    EXPECT_FLOAT_EQ(host[1], 0.5f);
+}
+


### PR DESCRIPTION
## Summary
- add CPU and CUDA tensor arithmetic tests using GoogleTest
- configure CMake to fetch GoogleTest and build tests
- enable testing in root build

## Testing
- `cmake -S . -B build` *(fails: Failed to find nvcc)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689300aa3120832b8f2752bca912f0ba