### PR TITLE
docs: fix static_assert messages in CPU op macros

### DIFF
--- a/headers/ops/cpu/binary_op_macros.h
+++ b/headers/ops/cpu/binary_op_macros.h
@@ -7,7 +7,7 @@
 #define DEFINE_BINARY_OPS_CPU(OP_NAME, OP_EXPR)\
     template<typename T>\
     void OP_NAME##_cpu(const TensorView<const T> lhs, const TensorView<const T> rhs, TensorView<T> dst) {\
-        static_assert(std::is_arithmetic_v<T>, "add_cpu requires an arithmetic type");\
+        static_assert(std::is_arithmetic_v<T>, "binary op requires an arithmetic type");\
 \
         if (!lhs.match(rhs)) {\
             throw std::runtime_error("Tensor dimensions must match for arithmetic operations");\

--- a/headers/ops/cpu/unary_op_macros.h
+++ b/headers/ops/cpu/unary_op_macros.h
@@ -7,7 +7,7 @@
 #define DEFINE_UNARY_OPS_CPU(OP_NAME, OP_EXPR)\
     template<typename T>\
     void OP_NAME##_cpu(const TensorView<const T> lhs, T value, TensorView<T> dst) {\
-        static_assert(is_extended_arithmetic<T>{}, "add_cpu requires an arithmetic type");\
+        static_assert(is_extended_arithmetic<T>{}, "unary op requires an arithmetic type");\
         size_t _total = lhs.size();\
         for(size_t idx = 0; idx < _total; ++idx)\
             dst[idx] = OP_EXPR;\


### PR DESCRIPTION
## Summary
- generalize static_assert messages for unary CPU ops
- generalize static_assert messages for binary CPU ops

## Testing
- `bash compile.sh` *(fails: Failed to find nvcc)*
- `apt-get update` *(fails: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6893060e97fc832bbc8733b2baaa0527