### PR TITLE
Fix fused operation kernels to reference tensor views correctly

### DIFF
--- a/headers/ops/kernels/fused_op.cuh
+++ b/headers/ops/kernels/fused_op.cuh
@@ -25,17 +25,10 @@ namespace om
     };
 
 
-    template<typename T>
-    __global__ void apply_op_rank1(DeviceTensorView<T> tensor, T value);
-    template<typename T>
-    __global__ void apply_op_rank2(DeviceTensorView<T> tensor, T value);
-    template<typename T>
-    __global__ void apply_op_rank3(DeviceTensorView<T> tensor, T value);
-    template<typename T>
-    __global__ void apply_op_rank4(DeviceTensorView<T> tensor, T value);
-    template<typename T>
-    __global__ void apply_op_nd(DeviceTensorView<T> tensor, T value);
-
-    template<typename T>
-    void launch_apply_op(TensorView<T> tensor, T value);
+    // Apply a unary operation \p op element-wise from \p src to \p dst.
+    //
+    // Kernels are defined in the corresponding .cu file; only the host
+    // dispatch function is exposed here.
+    template<typename T, typename Op>
+    void launch_apply_op(const TensorView<const T> src, TensorView<T> dst, Op op);
 }

--- a/src/ops/kernels/fused_op.cu
+++ b/src/ops/kernels/fused_op.cu
@@ -9,8 +9,8 @@ namespace om {
     template <typename T, typename Op>
     __global__ void apply_op_rank1(const DeviceTensorView<const T> src, DeviceTensorView<T> dst, Op op) {
         size_t x = blockIdx.x * blockDim.x + threadIdx.x;
-        if(x < tensor.shape[0])
-            dst(x) = op(src[idx]);
+        if (x < dst.shape[0])
+            dst(x) = op(src(x));
     }
     
     template <typename T, typename Op>
@@ -18,7 +18,7 @@ namespace om {
         size_t x = blockIdx.x * blockDim.x + threadIdx.x;
         size_t y = blockIdx.y * blockDim.y + threadIdx.y;
         
-        if(y < tensor.shape[0] && x < tensor.shape[1])
+        if (y < dst.shape[0] && x < dst.shape[1])
             dst(y, x) = op(src(y, x));
     }
     
@@ -28,8 +28,8 @@ namespace om {
         size_t y = blockIdx.y * blockDim.y + threadIdx.y;
         size_t z = blockIdx.z * blockDim.z + threadIdx.z;
         
-        if(z < tensor.shape[0] && y < tensor.shape[1] && x < tensor.shape[2])
-            dst(z, y, x) =  op(src(z, y, x));
+        if (z < dst.shape[0] && y < dst.shape[1] && x < dst.shape[2])
+            dst(z, y, x) = op(src(z, y, x));
     }
 
     template <typename T, typename Op>
@@ -38,12 +38,12 @@ namespace om {
         size_t h = threadIdx.y + blockIdx.y * blockDim.y;
         size_t n = blockIdx.z; // N dimension
     
-        for (size_t c = threadIdx.z; c < tensor.shape[1]; c += blockDim.z) {
-            if (n < tensor.shape[0] &&
-                c < tensor.shape[1] &&
-                h < tensor.shape[2] &&
-                w < tensor.shape[3]) {
-                    dst(n, c, h, w) =  op(src(n, c, h, w));
+        for (size_t c = threadIdx.z; c < dst.shape[1]; c += blockDim.z) {
+            if (n < dst.shape[0] &&
+                c < dst.shape[1] &&
+                h < dst.shape[2] &&
+                w < dst.shape[3]) {
+                dst(n, c, h, w) = op(src(n, c, h, w));
             }
         }
     }
@@ -51,16 +51,16 @@ namespace om {
     template <typename T, typename Op>
     __global__ void apply_op_nd(const DeviceTensorView<const T> src, DeviceTensorView<T> dst, Op op) {
         size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
-        size_t total_elements = tensor.size();
+        size_t total_elements = dst.size();
     
         if (idx >= total_elements) return;
     
         size_t offset = 0;
         size_t tmp = idx;
-        for (size_t d = 0; d < tensor.rank; ++d) {
-            size_t coord = tmp % tensor.shape[d];
-            offset += coord * tensor.stride[d];
-            tmp /= tensor.shape[d];
+        for (size_t d = 0; d < dst.rank; ++d) {
+            size_t coord = tmp % dst.shape[d];
+            offset += coord * dst.stride[d];
+            tmp /= dst.shape[d];
         }
     
         dst[offset] = op(src[offset]);
@@ -69,43 +69,46 @@ namespace om {
     template <typename T, typename Op>
     void launch_apply_op(const TensorView<const T> src, TensorView<T> dst, Op op)
     {
-        switch (tensor.rank)
+        if (!dst.match(src))
+            throw std::invalid_argument("Source and destination must have the same shape");
+
+        switch (dst.rank)
         {
         case 1:
             {
                 dim3 threads(16);
-                dim3 blocks((tensor.shape[0] + 15) / 16);
+                dim3 blocks((dst.shape[0] + 15) / 16);
                 apply_op_rank1<<<blocks, threads>>>(src.as_device_tw(), dst.as_device_tw(), op);
             }
             break;
         case 2:
             {
                 dim3 threads(16, 16);
-                dim3 blocks((tensor.shape[1] + 15) / 16, (tensor.shape[0] + 15) / 16);
+                dim3 blocks((dst.shape[1] + 15) / 16, (dst.shape[0] + 15) / 16);
                 apply_op_rank2<<<blocks, threads>>>(src.as_device_tw(), dst.as_device_tw(), op);
             }
-            break;        
+            break;
         case 3:
             {
-                dim3 threads(8, 8, 8); // solo 512 thread per blocco
-                dim3 blocks((tensor.shape[2] + 7) / 8, (tensor.shape[1] + 7) / 8, (tensor.shape[0] + 7) / 8);
+                dim3 threads(8, 8, 8); // 512 threads per block
+                dim3 blocks((dst.shape[2] + 7) / 8, (dst.shape[1] + 7) / 8, (dst.shape[0] + 7) / 8);
                 apply_op_rank3<<<blocks, threads>>>(src.as_device_tw(), dst.as_device_tw(), op);
             }
-            break;  
+            break;
         case 4:
             {
-                dim3 threads(8, 8, tensor.shape[1] < 8 ? tensor.shape[1] : 8); // evita z troppo grandi
+                dim3 threads(8, 8, dst.shape[1] < 8 ? dst.shape[1] : 8); // avoid large z
                 dim3 blocks(
-                    (tensor.shape[3] + threads.x - 1) / threads.x,
-                    (tensor.shape[2] + threads.y - 1) / threads.y,
-                    tensor.shape[0]
-                );                             
+                    (dst.shape[3] + threads.x - 1) / threads.x,
+                    (dst.shape[2] + threads.y - 1) / threads.y,
+                    dst.shape[0]
+                );
                 apply_op_rank4<<<blocks, threads>>>(src.as_device_tw(), dst.as_device_tw(), op);
             }
-            break;            
+            break;
         default:
             {
-                size_t total_elements = tensor.size();
+                size_t total_elements = dst.size();
                 dim3 threads(256);
                 dim3 blocks((total_elements + threads.x - 1) / threads.x);
                 apply_op_nd<<<blocks, threads>>>(src.as_device_tw(), dst.as_device_tw(), op);


### PR DESCRIPTION
## Summary
- expose only the dispatch helper in fused_op.cuh
- fix fused kernels to use src/dst shapes and add shape compatibility check

## Testing
- `cmake -S . -B build` (fails: Failed to find nvcc)
- `apt-get update` (fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)


------
https://chatgpt.com/codex/tasks/task_e_68930bb57034832b983da40010de5689